### PR TITLE
return promise in startLoading method

### DIFF
--- a/src/vuex-loading.js
+++ b/src/vuex-loading.js
@@ -139,15 +139,18 @@ function createActionHelpers({ moduleName }) {
     // start and stop helpers for async processes
     startLoading(dispatcher, loaderMessage, callback) {
       start(dispatcher, loaderMessage);
-      return callback()
-        .then(response => {
-          end(dispatcher, loaderMessage);
-          return response;
-        })
-        .catch(response => {
-          end(dispatcher, loaderMessage);
-          return Promise.reject(response);
-        });
+
+      return new Promise((resolve, reject) => {
+        callback()
+          .then(response => {
+            resolve(response);
+            end(dispatcher, loaderMessage);
+          })
+          .catch(response => {
+            end(dispatcher, loaderMessage);
+            reject(response);
+          });
+      });
     },
     endLoading(dispatcher, loaderMessage) {
       end(dispatcher, loaderMessage);

--- a/src/vuex-loading.js
+++ b/src/vuex-loading.js
@@ -147,8 +147,8 @@ function createActionHelpers({ moduleName }) {
             end(dispatcher, loaderMessage);
           })
           .catch(response => {
-            end(dispatcher, loaderMessage);
             reject(response);
+            end(dispatcher, loaderMessage);
           });
       });
     },


### PR DESCRIPTION
i have this in my acction

```js
export async function loadCampaign ({commit, dispatch}, {campaign, subscription}) {
  const url = route('api.campaigns.show', {campaign, subscription});

  commit(types.CAMPAIGN_REQUEST);

  try {
    const response = await startLoading(dispatch, 'load campaign', () => {
      return fetch(`${url}?include=tags`, {credentials: 'same-origin'})
        .then(response => response.json());
    });

    commit(
      types.CAMPAIGN_SUCCESS,
      normalize(response, schema.campaign)
    );
  } catch (err) {
    commit(types.CAMPAIGN_FAILURE, err);
  }
}
```

and in my view

```vue
<div v-if="!$isLoading('load campaign')">
     <h1>{{campaign.name}}</h1>
</div>
```

I have an error because the `loading` state is updated before my update and `campaign` has not been set.