### PR TITLE
fix error in createVuexLoader

### DIFF
--- a/src/vuex-loading.js
+++ b/src/vuex-loading.js
@@ -117,11 +117,13 @@ const createInstaller = function({ moduleName, componentName, className }) {
   };
 };
 
-function createVuexLoader({
-  moduleName = 'loading',
-  componentName = 'v-loading',
-  className = 'v-loading'
-}) {
+function createVuexLoader(
+  {
+    moduleName = 'loading',
+    componentName = 'v-loading',
+    className = 'v-loading'
+  } = {}
+) {
   return {
     install: createInstaller({ moduleName, componentName, className }),
     Store: createStore(moduleName)


### PR DESCRIPTION
When i use `createVuexLoader` without any param i get this error ` Cannot read property 'moduleName' of undefined`.