### PR TITLE
Use same "moduleName" throughout docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Stops the given loader.
 ```js
 import { createActionHelpers } from 'vuex-loading'
 const { startLoading, endLoading } = createActionHelpers({
-  moduleName: 'loader'
+  moduleName: 'loading'
 });
 ```
 


### PR DESCRIPTION
I tripped over the different "moduleName" in the documentation. This change should help people try out this package more easily.