### PR TITLE
Fix "button with loading state" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ In template, you should wrap your content with `v-loading` component to show loa
 Better example for a `button` with loading state:
 
 ```html
-<button :disabled='$isLoading("creating user")'>
+<button :disabled='$loading.isLoading("creating user")'>
   <v-loading loader='creating user'>
     <template slot='spinner'>Creating User...</template>
     Create User


### PR DESCRIPTION
`isLoading()` must be accessed via `$loading.isLoading`. This confused me when first setting up vuex-loading, since I used the button example first.